### PR TITLE
fix(frontend): resolve 2FA build issues

### DIFF
--- a/front/src/components/dashboard/TwoFactorSettings.tsx
+++ b/front/src/components/dashboard/TwoFactorSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { Button } from '../ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
@@ -22,7 +22,7 @@ import {
   Eye,
   EyeOff
 } from 'lucide-react';
-import { TwoFactorSetup } from '../../types/auth';
+import type { TwoFactorSetup } from '../../types/auth';
 
 export const TwoFactorSettings: React.FC = () => {
   const { user, setupTwoFactor, enableTwoFactor, disableTwoFactor, isLoading } = useAuth();
@@ -63,7 +63,7 @@ export const TwoFactorSettings: React.FC = () => {
     }
 
     try {
-      const response = await enableTwoFactor(totpCode);
+      const response = await enableTwoFactor(totpCode.trim());
       if (response.success) {
         setRecoveryCodes(response.recoveryCodes);
         setShowRecoveryCodes(true);
@@ -84,7 +84,7 @@ export const TwoFactorSettings: React.FC = () => {
     }
 
     try {
-      const response = await disableTwoFactor(disableCode);
+      const response = await disableTwoFactor(disableCode.trim());
       if (response.success) {
         setShowDisableDialog(false);
         setDisableCode('');

--- a/front/src/components/dashboard/sync/SyncPage.tsx
+++ b/front/src/components/dashboard/sync/SyncPage.tsx
@@ -86,19 +86,6 @@ export const SyncPage: React.FC = () => {
     }
   };
 
-  const handleSyncRouter = async (routerId: number) => {
-    setSyncing(true);
-    try {
-      await axios.post(`/api/sync/manual/${routerId}`);
-      await fetchSyncStatus();
-      await fetchSyncLogs();
-    } catch (err: any) {
-      setError(err.response?.data?.error || 'Error al sincronizar router');
-    } finally {
-      setSyncing(false);
-    }
-  };
-
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'success':


### PR DESCRIPTION
## Summary
- remove unused `useEffect` and treat `TwoFactorSetup` as a type-only import in TwoFactorSettings
- drop unused router-sync handler to stop TypeScript compile errors
- centralize axios config with a default backend URL so 2FA endpoints are correctly called
- default API base URL to HTTPS and trim 2FA codes before submission

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b12095df6c832b81d033c516d50a11