### PR TITLE
feat: enable user editing in dashboard

### DIFF
--- a/front/src/components/dashboard/Dashboard.tsx
+++ b/front/src/components/dashboard/Dashboard.tsx
@@ -9,7 +9,7 @@ import { RouterManagement } from './routers/RouterManagement';
 import { ClientManagement } from './clients/ClientManagement';
 import { SessionManagement } from '../sessions/SessionManagement';
 import { FirewallManagement } from './firewall/FirewallManagement';
-import { UsersPage } from './users/UsersPage';
+import { UserManagement } from './users/UserManagement';
 import { SyncPage } from './sync/SyncPage';
 import { BranchesPage } from './branches/BranchesPage';
 
@@ -26,7 +26,7 @@ export const Dashboard: React.FC = () => {
             <Route path="clients/*" element={<ClientManagement />} />
             <Route path="sessions/*" element={<SessionManagement />} />
             <Route path="firewall/*" element={<FirewallManagement />} />
-            <Route path="users/*" element={<UsersPage />} />
+            <Route path="users/*" element={<UserManagement />} />
             <Route path="sync/*" element={<SyncPage />} />
             <Route path="branches/*" element={<BranchesPage />} />
             <Route path="profile" element={<ProfileSettings />} />

--- a/front/src/components/dashboard/users/EditUser.tsx
+++ b/front/src/components/dashboard/users/EditUser.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams, Link } from 'react-router-dom';
+import axios from 'axios';
+import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
+import { Button } from '../../ui/button';
+import { Input } from '../../ui/input';
+import { Alert, AlertDescription } from '../../ui/alert';
+
+interface EditUserForm {
+  username: string;
+  email: string;
+  role: string;
+  is_active: boolean;
+}
+
+export const EditUser: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [formData, setFormData] = useState<EditUserForm>({
+    username: '',
+    email: '',
+    role: 'user',
+    is_active: true,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const response = await axios.get(`/api/users/${id}`);
+        const { username, email, role, is_active } = response.data;
+        setFormData({ username, email, role, is_active });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error desconocido');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchUser();
+  }, [id]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.put(`/api/users/${id}`, formData);
+      navigate('/dashboard/users');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error desconocido');
+    }
+  };
+
+  if (loading) {
+    return <div>Cargando...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Button asChild variant="outline">
+        <Link to="/dashboard/users">Volver</Link>
+      </Button>
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <Card>
+        <CardHeader>
+          <CardTitle>Editar Usuario</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-700">
+                Nombre de usuario
+              </label>
+              <Input
+                name="username"
+                value={formData.username}
+                onChange={handleChange}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700">
+                Email
+              </label>
+              <Input
+                type="email"
+                name="email"
+                value={formData.email}
+                onChange={handleChange}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700">
+                Rol
+              </label>
+              <select
+                name="role"
+                value={formData.role}
+                onChange={handleChange}
+                className="h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm"
+              >
+                <option value="admin">Administrador</option>
+                <option value="supervisor">Supervisor</option>
+                <option value="operator">Operador</option>
+                <option value="user">Usuario</option>
+              </select>
+            </div>
+            <div className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                id="is_active"
+                checked={formData.is_active}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, is_active: e.target.checked }))
+                }
+              />
+              <label htmlFor="is_active" className="text-sm text-slate-700">
+                Activo
+              </label>
+            </div>
+            <Button type="submit">Guardar</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default EditUser;

--- a/front/src/components/dashboard/users/UserManagement.tsx
+++ b/front/src/components/dashboard/users/UserManagement.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { UsersPage } from './UsersPage';
+import { EditUser } from './EditUser';
+
+export const UserManagement: React.FC = () => {
+  return (
+    <Routes>
+      <Route index element={<UsersPage />} />
+      <Route path=":id/edit" element={<EditUser />} />
+      <Route path="*" element={<Navigate to="/dashboard/users" replace />} />
+    </Routes>
+  );
+};
+
+export default UserManagement;

--- a/front/src/services/userService.ts
+++ b/front/src/services/userService.ts
@@ -12,7 +12,7 @@ export const userService = {
   },
 
   async getUser(id: number): Promise<UserData> {
-    const response = await axios.get(`${API_BASE_URL}/api/users${id}`);
+    const response = await axios.get(`${API_BASE_URL}/api/users/${id}`);
     return response.data;
   },
 
@@ -28,12 +28,12 @@ export const userService = {
   },
 
   async updateUser(id: number, data: Partial<UserData>): Promise<{ message: string }> {
-    const response = await axios.put(`${API_BASE_URL}/api/users${id}`, data);
+    const response = await axios.put(`${API_BASE_URL}/api/users/${id}`, data);
     return response.data;
   },
 
   async deleteUser(id: number): Promise<{ message: string }> {
-    const response = await axios.delete(`${API_BASE_URL}/api/users${id}`);
+    const response = await axios.delete(`${API_BASE_URL}/api/users/${id}`);
     return response.data;
   }
 };


### PR DESCRIPTION
## Summary
- add user management routes and edit user form
- fix user service endpoints to include missing slashes
- wire dashboard to new user management component

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/services/userService.ts src/components/dashboard/users/EditUser.tsx src/components/dashboard/users/UserManagement.tsx src/components/dashboard/Dashboard.tsx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1e915d7e4832b93adf01f33b57f72