### PR TITLE
Add branch CRUD with hard delete

### DIFF
--- a/front/src/components/dashboard/Dashboard.tsx
+++ b/front/src/components/dashboard/Dashboard.tsx
@@ -11,7 +11,7 @@ import { SessionManagement } from '../sessions/SessionManagement';
 import { FirewallManagement } from './firewall/FirewallManagement';
 import { UserManagement } from './users/UserManagement';
 import { SyncPage } from './sync/SyncPage';
-import { BranchesPage } from './branches/BranchesPage';
+import { BranchManagement } from './branches/BranchManagement';
 
 export const Dashboard: React.FC = () => {
   return (
@@ -28,7 +28,7 @@ export const Dashboard: React.FC = () => {
             <Route path="firewall/*" element={<FirewallManagement />} />
             <Route path="users/*" element={<UserManagement />} />
             <Route path="sync/*" element={<SyncPage />} />
-            <Route path="branches/*" element={<BranchesPage />} />
+            <Route path="branches/*" element={<BranchManagement />} />
             <Route path="profile" element={<ProfileSettings />} />
             <Route path="security" element={<TwoFactorSettings />} />
             <Route path="*" element={<Navigate to="/dashboard" replace />} />

--- a/front/src/components/dashboard/branches/BranchManagement.tsx
+++ b/front/src/components/dashboard/branches/BranchManagement.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { BranchesPage } from './BranchesPage';
+import { CreateBranch } from './CreateBranch';
+import { EditBranch } from './EditBranch';
+
+export const BranchManagement: React.FC = () => {
+  return (
+    <Routes>
+      <Route index element={<BranchesPage />} />
+      <Route path="new" element={<CreateBranch />} />
+      <Route path=":id/edit" element={<EditBranch />} />
+      <Route path="*" element={<Navigate to="/dashboard/branches" replace />} />
+    </Routes>
+  );
+};
+
+export default BranchManagement;
+

--- a/front/src/components/dashboard/branches/CreateBranch.tsx
+++ b/front/src/components/dashboard/branches/CreateBranch.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../ui/card';
+import { Button } from '../../ui/button';
+import { Input } from '../../ui/input';
+import { Label } from '../../ui/label';
+import { Alert, AlertDescription } from '../../ui/alert';
+import { ArrowLeft, Building2, AlertTriangle } from 'lucide-react';
+import { branchService } from '../../../services/branchService';
+
+export const CreateBranch: React.FC = () => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    name: '',
+    location: '',
+    is_active: true,
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value, type, checked } = e.target;
+    setFormData(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    try {
+      setLoading(true);
+      await branchService.createBranch({
+        name: formData.name,
+        location: formData.location || undefined,
+        is_active: formData.is_active,
+      });
+      navigate('/dashboard/branches');
+    } catch (err: any) {
+      const message = err.response?.data?.error || 'Error al crear la sucursal';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center space-x-4">
+        <Button variant="outline" onClick={() => navigate('/dashboard/branches')}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Volver
+        </Button>
+        <div>
+          <h1 className="text-3xl font-bold text-slate-900">Crear Nueva Sucursal</h1>
+          <p className="text-slate-600">Ingresa la información de la nueva sucursal</p>
+        </div>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center space-x-2">
+            <Building2 className="h-5 w-5" />
+            <span>Información de la Sucursal</span>
+          </CardTitle>
+          <CardDescription>Completa los datos de la sucursal</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">Nombre</Label>
+              <Input
+                id="name"
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
+                required
+                placeholder="Nombre de la sucursal"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="location">Ubicación</Label>
+              <Input
+                id="location"
+                name="location"
+                value={formData.location}
+                onChange={handleChange}
+                placeholder="Ubicación de la sucursal"
+              />
+            </div>
+            <div className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                id="is_active"
+                name="is_active"
+                checked={formData.is_active}
+                onChange={handleChange}
+              />
+              <Label htmlFor="is_active" className="text-sm text-slate-700">
+                Activa
+              </Label>
+            </div>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Guardando...' : 'Crear Sucursal'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default CreateBranch;
+

--- a/front/src/components/dashboard/branches/EditBranch.tsx
+++ b/front/src/components/dashboard/branches/EditBranch.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams, Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
+import { Button } from '../../ui/button';
+import { Input } from '../../ui/input';
+import { Label } from '../../ui/label';
+import { Alert, AlertDescription } from '../../ui/alert';
+import { AlertTriangle } from 'lucide-react';
+import { branchService } from '../../../services/branchService';
+import type { BranchResponse } from '../../../types/branch';
+
+export const EditBranch: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [formData, setFormData] = useState({
+    name: '',
+    location: '',
+    is_active: true,
+  });
+
+  useEffect(() => {
+    const fetchBranch = async () => {
+      try {
+        const response: BranchResponse = await branchService.getBranch(Number(id));
+        setFormData({
+          name: response.name,
+          location: response.location || '',
+          is_active: response.is_active,
+        });
+      } catch (err: any) {
+        const message = err.response?.data?.error || 'Error al cargar la sucursal';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchBranch();
+  }, [id]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value, type, checked } = e.target;
+    setFormData(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await branchService.updateBranch(Number(id), {
+        name: formData.name,
+        location: formData.location || undefined,
+        is_active: formData.is_active,
+      });
+      navigate('/dashboard/branches');
+    } catch (err: any) {
+      const message = err.response?.data?.error || 'Error al actualizar la sucursal';
+      setError(message);
+    }
+  };
+
+  if (loading) {
+    return <div>Cargando...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Button asChild variant="outline">
+        <Link to="/dashboard/branches">Volver</Link>
+      </Button>
+      {error && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <Card>
+        <CardHeader>
+          <CardTitle>Editar Sucursal</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <Label htmlFor="name" className="block text-sm font-medium text-slate-700">
+                Nombre
+              </Label>
+              <Input
+                id="name"
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="location" className="block text-sm font-medium text-slate-700">
+                Ubicación
+              </Label>
+              <Input
+                id="location"
+                name="location"
+                value={formData.location}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                id="is_active"
+                name="is_active"
+                checked={formData.is_active}
+                onChange={handleChange}
+              />
+              <Label htmlFor="is_active" className="text-sm text-slate-700">
+                Activa
+              </Label>
+            </div>
+            <Button type="submit">Guardar</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default EditBranch;
+

--- a/front/src/components/dashboard/sync/SyncPage.tsx
+++ b/front/src/components/dashboard/sync/SyncPage.tsx
@@ -86,19 +86,6 @@ export const SyncPage: React.FC = () => {
     }
   };
 
-  const handleSyncRouter = async (routerId: number) => {
-    setSyncing(true);
-    try {
-      await axios.post(`/api/sync/manual/${routerId}`);
-      await fetchSyncStatus();
-      await fetchSyncLogs();
-    } catch (err: any) {
-      setError(err.response?.data?.error || 'Error al sincronizar router');
-    } finally {
-      setSyncing(false);
-    }
-  };
-
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'success':

--- a/front/src/services/branchService.ts
+++ b/front/src/services/branchService.ts
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import type { BranchListResponse, BranchResponse, BasicResponse } from '../types/branch';
+
+const API_BASE_URL = import.meta.env.VITE_BACKEND_URL || '';
+
+export const branchService = {
+  async getBranches(page = 1, perPage = 20): Promise<BranchListResponse> {
+    const response = await axios.get(`${API_BASE_URL}/api/branches`, {
+      params: { page, per_page: perPage }
+    });
+    return response.data;
+  },
+
+  async getBranch(id: number): Promise<BranchResponse> {
+    const response = await axios.get(`${API_BASE_URL}/api/branches/${id}`);
+    return response.data;
+  },
+
+  async createBranch(data: { name: string; location?: string; is_active?: boolean }): Promise<BranchResponse> {
+    const response = await axios.post(`${API_BASE_URL}/api/branches`, data);
+    return response.data;
+  },
+
+  async updateBranch(id: number, data: { name?: string; location?: string; is_active?: boolean }): Promise<BranchResponse> {
+    const response = await axios.put(`${API_BASE_URL}/api/branches/${id}`, data);
+    return response.data;
+  },
+
+  async deleteBranch(id: number): Promise<BasicResponse> {
+    const response = await axios.delete(`${API_BASE_URL}/api/branches/${id}`);
+    return response.data;
+  }
+};
+
+export default branchService;
+

--- a/front/src/types/branch.ts
+++ b/front/src/types/branch.ts
@@ -1,0 +1,31 @@
+export interface BranchData {
+  id: number;
+  name: string;
+  location: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  routers_count?: number;
+}
+
+export interface BranchListResponse {
+  success: boolean;
+  branches: BranchData[];
+  pagination: {
+    page: number;
+    per_page: number;
+    total: number;
+    pages: number;
+  };
+}
+
+export interface BranchResponse extends BranchData {
+  success: boolean;
+  message?: string;
+}
+
+export interface BasicResponse {
+  success: boolean;
+  message?: string;
+}
+


### PR DESCRIPTION
## Summary
- Permanently remove branches and block deletion if routers are still linked
- Add branch service and React pages for listing, creating and editing branches
- Integrate branch management into dashboard navigation

## Testing
- `cd back && pytest`
- `cd front && npm test` *(fails: Missing script "test")*
- `cd front && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b39a5a0044832b8b917db934bf0ee9