### PR TITLE
fix: display client IP

### DIFF
--- a/front/src/components/dashboard/clients/ClientDetails.tsx
+++ b/front/src/components/dashboard/clients/ClientDetails.tsx
@@ -30,6 +30,7 @@ interface PPPoEClient {
   comment?: string;
   profile?: string;
   contract?: string;
+  ip?: string;
   ipAddress?: string;
   isActive: boolean;
   router?: {
@@ -353,10 +354,10 @@ export const ClientDetails: React.FC = () => {
                   <span className="text-sm font-medium">Estado:</span>
                   {getStatusBadge(client.isActive)}
                 </div>
-                {client.ipAddress && (
+                {(client.ip || client.ipAddress) && (
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium">IP:</span>
-                    <span className="text-sm font-mono">{client.ipAddress}</span>
+                    <span className="text-sm font-mono">{client.ip || client.ipAddress}</span>
                   </div>
                 )}
                 {client.profile && (

--- a/front/src/components/dashboard/clients/ClientList.tsx
+++ b/front/src/components/dashboard/clients/ClientList.tsx
@@ -373,7 +373,7 @@ export const ClientList: React.FC = () => {
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-slate-600">IP:</span>
-                  <span className="text-sm font-mono text-slate-900">{client.ipAddress || 'Sin IP asignada'}</span>
+                  <span className="text-sm font-mono text-slate-900">{client.ip || client.ipAddress || 'Sin IP asignada'}</span>
                 </div>
                 {client.profile && (
                   <div className="flex items-center justify-between">

--- a/front/src/components/dashboard/clients/CreateClient.tsx
+++ b/front/src/components/dashboard/clients/CreateClient.tsx
@@ -42,6 +42,7 @@ interface PPPoEClient {
   comment?: string;
   profile?: string;
   contract?: string;
+  ip?: string;
   ipAddress?: string;
   isActive: boolean;
   router?: {
@@ -358,10 +359,10 @@ export const CreateClient: React.FC = () => {
                   <span className="text-sm font-medium">Estado:</span>
                   {getStatusBadge(client.isActive)}
                 </div>
-                {client.ipAddress && (
+                {(client.ip || client.ipAddress) && (
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium">IP:</span>
-                    <span className="text-sm font-mono">{client.ipAddress}</span>
+                    <span className="text-sm font-mono">{client.ip || client.ipAddress}</span>
                   </div>
                 )}
                 {client.profile && (

--- a/front/src/components/sessions/SessionManagement.tsx
+++ b/front/src/components/sessions/SessionManagement.tsx
@@ -27,7 +27,8 @@ interface ActiveSession {
   id: string;
   clientName: string;
   clientId?: string;
-  address: string;
+  address?: string;
+  'remote-address'?: string;
   uptime: string;
   rxBytes: number;
   txBytes: number;
@@ -184,12 +185,14 @@ export const SessionManagement: React.FC = () => {
 
   // Filter sessions based on search and router selection
   const filteredSessions = sessions.filter(session => {
-    const matchesSearch = session.clientName.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         session.address.includes(searchTerm) ||
-                         session.routerName.toLowerCase().includes(searchTerm.toLowerCase());
-    
+    const ip = session.address || session['remote-address'] || '';
+    const matchesSearch =
+      session.clientName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      ip.includes(searchTerm) ||
+      session.routerName.toLowerCase().includes(searchTerm.toLowerCase());
+
     const matchesRouter = !selectedRouter || session.routerId === selectedRouter;
-    
+
     return matchesSearch && matchesRouter;
   });
 
@@ -367,7 +370,7 @@ export const SessionManagement: React.FC = () => {
                           )}
                         </div>
                         <p className="text-sm text-slate-600">
-                          {session.address} • {session.routerName}
+                          {session.address || session['remote-address']} • {session.routerName}
                         </p>
                       </div>
                     </div>

--- a/front/src/types/router.ts
+++ b/front/src/types/router.ts
@@ -29,7 +29,8 @@ export interface PPPoEClient {
   id: string;
   routerId: number;
   router?: Router;
-  ipAddress: string;
+  ip?: string;
+  ipAddress?: string;
   name: string;
   password: string;
   comment?: string;
@@ -46,7 +47,8 @@ export interface PPPoESession {
   id: string;
   clientId: string;
   client?: PPPoEClient;
-  ipAddress: string;
+  ip?: string;
+  ipAddress?: string;
   uptime: string;
   bytesIn: number;
   bytesOut: number;
@@ -126,7 +128,7 @@ export interface ActivityLog {
   routerId: number;
   router?: Router;
   userId: number;
-  user?: any;
+  user?: unknown;
   action: string;
   description?: string;
   ipAddress?: string;
@@ -248,5 +250,6 @@ export interface PPPoEClientFilters {
 export interface SessionFilters {
   routerId?: number;
   clientId?: string;
+  ip?: string;
   ipAddress?: string;
 }


### PR DESCRIPTION
## Summary
- show PPPoE client IPs using `ip` or legacy `ipAddress`
- accept both IP field names in client details and create views
- extend PPPoE types for alternate IP field and tidy ActivityLog types

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 29 errors, 1 warning)
- `npx eslint src/components/dashboard/clients/ClientList.tsx src/components/dashboard/clients/ClientDetails.tsx src/components/dashboard/clients/CreateClient.tsx src/types/router.ts`

------
https://chatgpt.com/codex/tasks/task_e_68baf4f5cae4832bb4a46667b7cf7131